### PR TITLE
Don't install methods in FALLBACK

### DIFF
--- a/lib/Test/Base/Block.pm
+++ b/lib/Test/Base/Block.pm
@@ -24,7 +24,6 @@ method AT-KEY(Str $key) {
 }
 
 method FALLBACK($name) {
-    ::?CLASS.^add_method($name, method () { $!data{$name} });
     return $!data{$name};
 }
 


### PR DESCRIPTION
While this has sort of worked in the past (however, would have been vulnerable to crashes in the case of parallelism), it depends on an implementation detail of method caching. Upcoming Rakudo changes in this area thus result in a test failure for this module. Furthermore, since the same changes also will allow for calls made to `FALLBACK` to be as efficient as an installed method, any performance benefits of installing a method in `FALLBACK` also no longer apply.